### PR TITLE
use BLOCK_CHANGE_RECORD_ARRAY

### DIFF
--- a/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_10to1_11/packets/BlockItemPackets1_11.java
+++ b/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_10to1_11/packets/BlockItemPackets1_11.java
@@ -22,6 +22,7 @@ import nl.matsv.viabackwards.protocol.protocol1_12to1_11_1.data.BlockColors;
 import nl.matsv.viabackwards.utils.Block;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.data.UserConnection;
+import us.myles.ViaVersion.api.minecraft.BlockChangeRecord;
 import us.myles.ViaVersion.api.minecraft.chunks.Chunk;
 import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.minecraft.metadata.Metadata;
@@ -269,18 +270,13 @@ public class BlockItemPackets1_11 extends BlockItemRewriter<Protocol1_10To1_11> 
                     public void registerMap() {
                         map(Type.INT); // 0 - Chunk X
                         map(Type.INT); // 1 - Chunk Z
+                        map(Type.BLOCK_CHANGE_RECORD_ARRAY);
 
                         handler(new PacketHandler() {
                             @Override
                             public void handle(PacketWrapper wrapper) throws Exception {
-                                int count = wrapper.passthrough(Type.VAR_INT); // Array length
-
-                                for (int i = 0; i < count; i++) {
-                                    wrapper.passthrough(Type.UNSIGNED_BYTE); // Horizontal position
-                                    wrapper.passthrough(Type.UNSIGNED_BYTE); // Y coords
-
-                                    int id = wrapper.read(Type.VAR_INT); // Block ID
-                                    wrapper.write(Type.VAR_INT, handleBlockID(id));
+                                for (BlockChangeRecord record : wrapper.get(Type.BLOCK_CHANGE_RECORD_ARRAY, 0)) {
+                                    record.setBlockId(handleBlockID(record.getBlockId()));
                                 }
                             }
                         });

--- a/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12to1_11_1/packets/BlockItemPackets1_12.java
+++ b/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12to1_11_1/packets/BlockItemPackets1_12.java
@@ -16,6 +16,7 @@ import nl.matsv.viabackwards.protocol.protocol1_12to1_11_1.data.BlockColors;
 import nl.matsv.viabackwards.protocol.protocol1_12to1_11_1.data.MapColorMapping;
 import nl.matsv.viabackwards.utils.Block;
 import us.myles.ViaVersion.api.PacketWrapper;
+import us.myles.ViaVersion.api.minecraft.BlockChangeRecord;
 import us.myles.ViaVersion.api.minecraft.chunks.Chunk;
 import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.minecraft.metadata.Metadata;
@@ -242,18 +243,13 @@ public class BlockItemPackets1_12 extends BlockItemRewriter<Protocol1_11_1To1_12
                     public void registerMap() {
                         map(Type.INT); // 0 - Chunk X
                         map(Type.INT); // 1 - Chunk Z
+                        map(Type.BLOCK_CHANGE_RECORD_ARRAY);
 
                         handler(new PacketHandler() {
                             @Override
                             public void handle(PacketWrapper wrapper) throws Exception {
-                                int count = wrapper.passthrough(Type.VAR_INT); // Array length
-
-                                for (int i = 0; i < count; i++) {
-                                    wrapper.passthrough(Type.UNSIGNED_BYTE); // Horizontal position
-                                    wrapper.passthrough(Type.UNSIGNED_BYTE); // Y coords
-
-                                    int id = wrapper.read(Type.VAR_INT); // Block ID
-                                    wrapper.write(Type.VAR_INT, handleBlockID(id));
+                                for (BlockChangeRecord record : wrapper.get(Type.BLOCK_CHANGE_RECORD_ARRAY, 0)) {
+                                    record.setBlockId(handleBlockID(record.getBlockId()));
                                 }
                             }
                         });

--- a/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_9_4to1_10/packets/BlockItemPackets1_10.java
+++ b/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_9_4to1_10/packets/BlockItemPackets1_10.java
@@ -14,6 +14,7 @@ import nl.matsv.viabackwards.api.rewriters.BlockItemRewriter;
 import nl.matsv.viabackwards.protocol.protocol1_9_4to1_10.Protocol1_9_4To1_10;
 import nl.matsv.viabackwards.utils.Block;
 import us.myles.ViaVersion.api.PacketWrapper;
+import us.myles.ViaVersion.api.minecraft.BlockChangeRecord;
 import us.myles.ViaVersion.api.minecraft.chunks.Chunk;
 import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.minecraft.metadata.Metadata;
@@ -199,18 +200,13 @@ public class BlockItemPackets1_10 extends BlockItemRewriter<Protocol1_9_4To1_10>
                     public void registerMap() {
                         map(Type.INT); // 0 - Chunk X
                         map(Type.INT); // 1 - Chunk Z
+                        map(Type.BLOCK_CHANGE_RECORD_ARRAY);
 
                         handler(new PacketHandler() {
                             @Override
                             public void handle(PacketWrapper wrapper) throws Exception {
-                                int count = wrapper.passthrough(Type.VAR_INT); // Array length
-
-                                for (int i = 0; i < count; i++) {
-                                    wrapper.passthrough(Type.UNSIGNED_BYTE); // Horizontal position
-                                    wrapper.passthrough(Type.UNSIGNED_BYTE); // Y coords
-
-                                    int id = wrapper.read(Type.VAR_INT); // Block ID
-                                    wrapper.write(Type.VAR_INT, handleBlockID(id));
+                                for (BlockChangeRecord record : wrapper.get(Type.BLOCK_CHANGE_RECORD_ARRAY, 0)) {
+                                    record.setBlockId(handleBlockID(record.getBlockId()));
                                 }
                             }
                         });


### PR DESCRIPTION
Use the BLOCK_CHANGE_RECORD_ARRAY type in mutli block change packets, as it is used everywhere in ViaVersion, in the 1.13 ViaBackwards builds and I changed it in ViaRewind too.