### PR TITLE
remove unused colors from team prefix/suffix

### DIFF
--- a/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/packets/PlayerPacket1_13.java
+++ b/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/packets/PlayerPacket1_13.java
@@ -119,12 +119,12 @@ public class PlayerPacket1_13 extends Rewriter<Protocol1_12_2To1_13> {
 							//TODO team color/prefix handling changed from 1.12.2 to 1.13 and to 1.13.1 again afaik
 							String prefix = wrapper.read(Type.STRING);
 							String suffix = wrapper.read(Type.STRING);
-							prefix = prefix == null ? "" : ChatRewriter.jsonTextToLegacy(prefix);
+							prefix = prefix == null || prefix.equals("null") ? "" : ChatRewriter.jsonTextToLegacy(prefix);
 							prefix += "§" + (colour > -1 && colour <= 15 ? Integer.toHexString(colour) : "r");
 							prefix = ChatUtil.removeUnusedColor(prefix, 'f', true);
 							if (prefix.length() > 16) prefix = prefix.substring(0, 16);
 							if (prefix.endsWith("§")) prefix = prefix.substring(0, prefix.length() - 1);
-							suffix = suffix == null ? "" : ChatRewriter.jsonTextToLegacy(suffix);
+							suffix = suffix == null || suffix.equals("null") ? "" : ChatRewriter.jsonTextToLegacy(suffix);
 							suffix = ChatUtil.removeUnusedColor(suffix, 'f');
 							if (suffix.endsWith("§")) suffix = suffix.substring(0, suffix.length() - 1);
 							wrapper.write(Type.STRING, prefix);

--- a/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/packets/PlayerPacket1_13.java
+++ b/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/packets/PlayerPacket1_13.java
@@ -3,6 +3,7 @@ package nl.matsv.viabackwards.protocol.protocol1_12_2to1_13.packets;
 import nl.matsv.viabackwards.ViaBackwards;
 import nl.matsv.viabackwards.api.rewriters.Rewriter;
 import nl.matsv.viabackwards.protocol.protocol1_12_2to1_13.Protocol1_12_2To1_13;
+import nl.matsv.viabackwards.utils.ChatUtil;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.minecraft.Position;
 import us.myles.ViaVersion.api.minecraft.item.Item;
@@ -102,6 +103,7 @@ public class PlayerPacket1_13 extends Rewriter<Protocol1_12_2To1_13> {
 						if (action == 0 || action == 2) {
 							String displayName = wrapper.read(Type.STRING);
 							displayName = ChatRewriter.jsonTextToLegacy(displayName);
+							displayName = ChatUtil.removeUnusedColor(displayName, 'f');
 							if (displayName.length() > 32) displayName = displayName.substring(0, 32);
 							wrapper.write(Type.STRING, displayName);
 
@@ -119,9 +121,11 @@ public class PlayerPacket1_13 extends Rewriter<Protocol1_12_2To1_13> {
 							String suffix = wrapper.read(Type.STRING);
 							prefix = ChatRewriter.jsonTextToLegacy(prefix);
 							prefix += "§" + (colour > -1 && colour <= 15 ? Integer.toHexString(colour) : "r");
+							prefix = ChatUtil.removeUnusedColor(prefix, 'f', true);
 							if (prefix.length() > 16) prefix = prefix.substring(0, 16);
 							if (prefix.endsWith("§")) prefix = prefix.substring(0, prefix.length() - 1);
 							suffix = ChatRewriter.jsonTextToLegacy(suffix);
+							suffix = ChatUtil.removeUnusedColor(suffix, 'f');
 							if (suffix.endsWith("§")) suffix = suffix.substring(0, suffix.length() - 1);
 							wrapper.write(Type.STRING, prefix);
 							wrapper.write(Type.STRING, suffix);

--- a/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/packets/PlayerPacket1_13.java
+++ b/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/packets/PlayerPacket1_13.java
@@ -15,143 +15,143 @@ import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.ChatRewriter;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.packets.InventoryPackets;
 
 public class PlayerPacket1_13 extends Rewriter<Protocol1_12_2To1_13> {
-	@Override
-	protected void registerPackets(Protocol1_12_2To1_13 protocol) {
+    @Override
+    protected void registerPackets(Protocol1_12_2To1_13 protocol) {
 
-		//Plugin Message
-		protocol.out(State.PLAY, 0x19, 0x18, new PacketRemapper() {
-			@Override
-			public void registerMap() {
-				handler(new PacketHandler() {
-					@Override
-					public void handle(PacketWrapper wrapper) throws Exception {
-						String channel = wrapper.read(Type.STRING);
-						if (channel.equals("minecraft:trader_list")) {
-							wrapper.write(Type.STRING, "MC|TrList");
-							wrapper.passthrough(Type.INT); //Passthrough Window ID
+        //Plugin Message
+        protocol.out(State.PLAY, 0x19, 0x18, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        String channel = wrapper.read(Type.STRING);
+                        if (channel.equals("minecraft:trader_list")) {
+                            wrapper.write(Type.STRING, "MC|TrList");
+                            wrapper.passthrough(Type.INT); //Passthrough Window ID
 
-							int size = wrapper.passthrough(Type.UNSIGNED_BYTE);
-							for (int i = 0; i < size; i++) {
-								//Input Item
-								Item input = wrapper.read(Type.FLAT_ITEM);
-								BlockItemPackets1_13.toClient(input);
-								wrapper.write(Type.ITEM, input);
-								//Output Item
-								Item output = wrapper.read(Type.FLAT_ITEM);
-								BlockItemPackets1_13.toClient(output);
-								wrapper.write(Type.ITEM, output);
+                            int size = wrapper.passthrough(Type.UNSIGNED_BYTE);
+                            for (int i = 0; i < size; i++) {
+                                //Input Item
+                                Item input = wrapper.read(Type.FLAT_ITEM);
+                                BlockItemPackets1_13.toClient(input);
+                                wrapper.write(Type.ITEM, input);
+                                //Output Item
+                                Item output = wrapper.read(Type.FLAT_ITEM);
+                                BlockItemPackets1_13.toClient(output);
+                                wrapper.write(Type.ITEM, output);
 
-								boolean secondItem = wrapper.passthrough(Type.BOOLEAN); //Has second item
-								if (secondItem) {
-									//Second Item
-									Item second = wrapper.read(Type.FLAT_ITEM);
-									BlockItemPackets1_13.toClient(second);
-									wrapper.write(Type.ITEM, second);
-								}
+                                boolean secondItem = wrapper.passthrough(Type.BOOLEAN); //Has second item
+                                if (secondItem) {
+                                    //Second Item
+                                    Item second = wrapper.read(Type.FLAT_ITEM);
+                                    BlockItemPackets1_13.toClient(second);
+                                    wrapper.write(Type.ITEM, second);
+                                }
 
-								wrapper.passthrough(Type.BOOLEAN); //Trade disabled
-								wrapper.passthrough(Type.INT); //Number of tools uses
-								wrapper.passthrough(Type.INT); //Maximum number of trade uses
-							}
-						} else {
-							String oldChannel = InventoryPackets.getOldPluginChannelId(channel);
-							if (oldChannel == null) {
-								ViaBackwards.getPlatform().getLogger().warning("Could not find old channel for " + channel);
-								wrapper.cancel();
-								return;
-							}
-							wrapper.write(Type.STRING, oldChannel);
-						}
-					}
-				});
-			}
-		});
+                                wrapper.passthrough(Type.BOOLEAN); //Trade disabled
+                                wrapper.passthrough(Type.INT); //Number of tools uses
+                                wrapper.passthrough(Type.INT); //Maximum number of trade uses
+                            }
+                        } else {
+                            String oldChannel = InventoryPackets.getOldPluginChannelId(channel);
+                            if (oldChannel == null) {
+                                ViaBackwards.getPlatform().getLogger().warning("Could not find old channel for " + channel);
+                                wrapper.cancel();
+                                return;
+                            }
+                            wrapper.write(Type.STRING, oldChannel);
+                        }
+                    }
+                });
+            }
+        });
 
-		//Scoreboard Objective
-		protocol.out(State.PLAY, 0x45, 0x42, new PacketRemapper() {
-			@Override
-			public void registerMap() {
-				map(Type.STRING);
-				map(Type.BYTE);
-				handler(new PacketHandler() {
-					@Override
-					public void handle(PacketWrapper wrapper) throws Exception {
-						byte mode = wrapper.get(Type.BYTE, 0);
-						if (mode == 0 || mode == 2) {
-							String value = wrapper.read(Type.STRING);
-							value = ChatRewriter.jsonTextToLegacy(value);
-							if (value.length() > 32) value = value.substring(0, 32);
-							wrapper.write(Type.STRING, value);
-							int type = wrapper.read(Type.VAR_INT);
-							wrapper.write(Type.STRING, type == 1 ? "hearts" : "integer");
-						}
-					}
-				});
-			}
-		});
+        //Scoreboard Objective
+        protocol.out(State.PLAY, 0x45, 0x42, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.STRING);
+                map(Type.BYTE);
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        byte mode = wrapper.get(Type.BYTE, 0);
+                        if (mode == 0 || mode == 2) {
+                            String value = wrapper.read(Type.STRING);
+                            value = ChatRewriter.jsonTextToLegacy(value);
+                            if (value.length() > 32) value = value.substring(0, 32);
+                            wrapper.write(Type.STRING, value);
+                            int type = wrapper.read(Type.VAR_INT);
+                            wrapper.write(Type.STRING, type == 1 ? "hearts" : "integer");
+                        }
+                    }
+                });
+            }
+        });
 
-		//Teams
-		protocol.out(State.PLAY, 0x47, 0x44, new PacketRemapper() {
-			@Override
-			public void registerMap() {
-				map(Type.STRING);
-				map(Type.BYTE);
-				handler(new PacketHandler() {
-					@Override
-					public void handle(PacketWrapper wrapper) throws Exception {
-						byte action = wrapper.get(Type.BYTE, 0);
-						if (action == 0 || action == 2) {
-							String displayName = wrapper.read(Type.STRING);
-							displayName = ChatRewriter.jsonTextToLegacy(displayName);
-							displayName = ChatUtil.removeUnusedColor(displayName, 'f');
-							if (displayName.length() > 32) displayName = displayName.substring(0, 32);
-							wrapper.write(Type.STRING, displayName);
+        //Teams
+        protocol.out(State.PLAY, 0x47, 0x44, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.STRING);
+                map(Type.BYTE);
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        byte action = wrapper.get(Type.BYTE, 0);
+                        if (action == 0 || action == 2) {
+                            String displayName = wrapper.read(Type.STRING);
+                            displayName = ChatRewriter.jsonTextToLegacy(displayName);
+                            displayName = ChatUtil.removeUnusedColor(displayName, 'f');
+                            if (displayName.length() > 32) displayName = displayName.substring(0, 32);
+                            wrapper.write(Type.STRING, displayName);
 
-							byte flags = wrapper.read(Type.BYTE);
-							String nameTagVisibility = wrapper.read(Type.STRING);
-							String collisionRule = wrapper.read(Type.STRING);
+                            byte flags = wrapper.read(Type.BYTE);
+                            String nameTagVisibility = wrapper.read(Type.STRING);
+                            String collisionRule = wrapper.read(Type.STRING);
 
-							int colour = wrapper.read(Type.VAR_INT);
-							if (colour == 21) {
-								colour = -1;
-							}
+                            int colour = wrapper.read(Type.VAR_INT);
+                            if (colour == 21) {
+                                colour = -1;
+                            }
 
-							//TODO team color/prefix handling changed from 1.12.2 to 1.13 and to 1.13.1 again afaik
-							String prefix = wrapper.read(Type.STRING);
-							String suffix = wrapper.read(Type.STRING);
-							prefix = prefix == null || prefix.equals("null") ? "" : ChatRewriter.jsonTextToLegacy(prefix);
-							prefix += "§" + (colour > -1 && colour <= 15 ? Integer.toHexString(colour) : "r");
-							prefix = ChatUtil.removeUnusedColor(prefix, 'f', true);
-							if (prefix.length() > 16) prefix = prefix.substring(0, 16);
-							if (prefix.endsWith("§")) prefix = prefix.substring(0, prefix.length() - 1);
-							suffix = suffix == null || suffix.equals("null") ? "" : ChatRewriter.jsonTextToLegacy(suffix);
-							suffix = ChatUtil.removeUnusedColor(suffix, 'f');
-							if (suffix.endsWith("§")) suffix = suffix.substring(0, suffix.length() - 1);
-							wrapper.write(Type.STRING, prefix);
-							wrapper.write(Type.STRING, suffix);
+                            //TODO team color/prefix handling changed from 1.12.2 to 1.13 and to 1.13.1 again afaik
+                            String prefix = wrapper.read(Type.STRING);
+                            String suffix = wrapper.read(Type.STRING);
+                            prefix = prefix == null || prefix.equals("null") ? "" : ChatRewriter.jsonTextToLegacy(prefix);
+                            prefix += "§" + (colour > -1 && colour <= 15 ? Integer.toHexString(colour) : "r");
+                            prefix = ChatUtil.removeUnusedColor(prefix, 'f', true);
+                            if (prefix.length() > 16) prefix = prefix.substring(0, 16);
+                            if (prefix.endsWith("§")) prefix = prefix.substring(0, prefix.length() - 1);
+                            suffix = suffix == null || suffix.equals("null") ? "" : ChatRewriter.jsonTextToLegacy(suffix);
+                            suffix = ChatUtil.removeUnusedColor(suffix, 'f');
+                            if (suffix.endsWith("§")) suffix = suffix.substring(0, suffix.length() - 1);
+                            wrapper.write(Type.STRING, prefix);
+                            wrapper.write(Type.STRING, suffix);
 
-							wrapper.write(Type.BYTE, flags);
-							wrapper.write(Type.STRING, nameTagVisibility);
-							wrapper.write(Type.STRING, collisionRule);
+                            wrapper.write(Type.BYTE, flags);
+                            wrapper.write(Type.STRING, nameTagVisibility);
+                            wrapper.write(Type.STRING, collisionRule);
 
-							wrapper.write(Type.BYTE, (byte) colour);
-						}
+                            wrapper.write(Type.BYTE, (byte) colour);
+                        }
 
-						if (action == 0 || action == 3 || action == 4) {
-							wrapper.passthrough(Type.STRING_ARRAY); //Entities
-						}
-					}
-				});
-			}
-		});
+                        if (action == 0 || action == 3 || action == 4) {
+                            wrapper.passthrough(Type.STRING_ARRAY); //Entities
+                        }
+                    }
+                });
+            }
+        });
 
         // Tab-Complete (clientbound) TODO MODIFIED
         protocol.out(State.PLAY, 0x10, 0x0E, new PacketRemapper() {
             @Override
-			public void registerMap() {
-				handler(new PacketHandler() {
-					@Override
-					public void handle(PacketWrapper wrapper) throws Exception {
+            public void registerMap() {
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
                         int key = wrapper.read(Type.VAR_INT);
                         int start = wrapper.read(Type.VAR_INT);
                         int length = wrapper.read(Type.VAR_INT);
@@ -163,10 +163,10 @@ public class PlayerPacket1_13 extends Rewriter<Protocol1_12_2To1_13> {
                             // Ignore tooltip
                             wrapper.read(Type.OPTIONAL_CHAT);
                         }
-					}
-				});
-			}
-		});
+                    }
+                });
+            }
+        });
 
         // Tab-Complete (serverbound)
         protocol.in(State.PLAY, 0x05, 0x01, new PacketRemapper() {
@@ -189,7 +189,7 @@ public class PlayerPacket1_13 extends Rewriter<Protocol1_12_2To1_13> {
                         // Ignore fields
                         wrapper.read(Type.BOOLEAN);
                         if (wrapper.read(Type.BOOLEAN)) {
-	                        wrapper.read(Type.POSITION);
+                            wrapper.read(Type.POSITION);
                         }
                     }
                 });
@@ -304,8 +304,8 @@ public class PlayerPacket1_13 extends Rewriter<Protocol1_12_2To1_13> {
         });
     }
 
-	@Override
-	protected void registerRewrites() {
+    @Override
+    protected void registerRewrites() {
 
-	}
+    }
 }

--- a/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/packets/PlayerPacket1_13.java
+++ b/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/packets/PlayerPacket1_13.java
@@ -119,12 +119,12 @@ public class PlayerPacket1_13 extends Rewriter<Protocol1_12_2To1_13> {
 							//TODO team color/prefix handling changed from 1.12.2 to 1.13 and to 1.13.1 again afaik
 							String prefix = wrapper.read(Type.STRING);
 							String suffix = wrapper.read(Type.STRING);
-							prefix = ChatRewriter.jsonTextToLegacy(prefix);
+							prefix = prefix == null ? "" : ChatRewriter.jsonTextToLegacy(prefix);
 							prefix += "§" + (colour > -1 && colour <= 15 ? Integer.toHexString(colour) : "r");
 							prefix = ChatUtil.removeUnusedColor(prefix, 'f', true);
 							if (prefix.length() > 16) prefix = prefix.substring(0, 16);
 							if (prefix.endsWith("§")) prefix = prefix.substring(0, prefix.length() - 1);
-							suffix = ChatRewriter.jsonTextToLegacy(suffix);
+							suffix = suffix == null ? "" : ChatRewriter.jsonTextToLegacy(suffix);
 							suffix = ChatUtil.removeUnusedColor(suffix, 'f');
 							if (suffix.endsWith("§")) suffix = suffix.substring(0, suffix.length() - 1);
 							wrapper.write(Type.STRING, prefix);

--- a/core/src/main/java/nl/matsv/viabackwards/utils/ChatUtil.java
+++ b/core/src/main/java/nl/matsv/viabackwards/utils/ChatUtil.java
@@ -1,0 +1,32 @@
+package nl.matsv.viabackwards.utils;
+
+import java.util.regex.Pattern;
+
+public class ChatUtil {
+	private static final Pattern UNUSED_COLOR_PATTERN = Pattern.compile("(?>(?>§[0-fk-or])*(§r|\\Z))|(?>(?>§[0-f])*(§[0-f]))");
+	private static final Pattern UNUSED_COLOR_PATTERN_PREFIX = Pattern.compile("(?>(?>§[0-fk-or])*(§r))|(?>(?>§[0-f])*(§[0-f]))");
+
+	public static String removeUnusedColor(String legacy, char defaultColor) {
+		return removeUnusedColor(legacy, defaultColor, false);
+	}
+
+	public static String removeUnusedColor(String legacy, char defaultColor, boolean isPrefix) {
+		if (legacy == null) return null;
+		Pattern pattern = isPrefix ? UNUSED_COLOR_PATTERN_PREFIX : UNUSED_COLOR_PATTERN;
+		legacy = pattern.matcher(legacy).replaceAll("$1$2");
+		StringBuilder builder = new StringBuilder();
+		char last = defaultColor;
+		for (int i = 0; i < legacy.length(); i++) {
+			char current = legacy.charAt(i);
+			if (current != '§' || i == legacy.length() - 1) {
+				builder.append(current);
+				continue;
+			}
+			current = legacy.charAt(++i);
+			if (current == last) continue;
+			builder.append('§').append(current);
+			last = current;
+		}
+		return builder.toString();
+	}
+}

--- a/core/src/main/java/nl/matsv/viabackwards/utils/ChatUtil.java
+++ b/core/src/main/java/nl/matsv/viabackwards/utils/ChatUtil.java
@@ -3,30 +3,30 @@ package nl.matsv.viabackwards.utils;
 import java.util.regex.Pattern;
 
 public class ChatUtil {
-	private static final Pattern UNUSED_COLOR_PATTERN = Pattern.compile("(?>(?>§[0-fk-or])*(§r|\\Z))|(?>(?>§[0-f])*(§[0-f]))");
-	private static final Pattern UNUSED_COLOR_PATTERN_PREFIX = Pattern.compile("(?>(?>§[0-fk-or])*(§r))|(?>(?>§[0-f])*(§[0-f]))");
+    private static final Pattern UNUSED_COLOR_PATTERN = Pattern.compile("(?>(?>§[0-fk-or])*(§r|\\Z))|(?>(?>§[0-f])*(§[0-f]))");
+    private static final Pattern UNUSED_COLOR_PATTERN_PREFIX = Pattern.compile("(?>(?>§[0-fk-or])*(§r))|(?>(?>§[0-f])*(§[0-f]))");
 
-	public static String removeUnusedColor(String legacy, char defaultColor) {
-		return removeUnusedColor(legacy, defaultColor, false);
-	}
+    public static String removeUnusedColor(String legacy, char defaultColor) {
+        return removeUnusedColor(legacy, defaultColor, false);
+    }
 
-	public static String removeUnusedColor(String legacy, char defaultColor, boolean isPrefix) {
-		if (legacy == null) return null;
-		Pattern pattern = isPrefix ? UNUSED_COLOR_PATTERN_PREFIX : UNUSED_COLOR_PATTERN;
-		legacy = pattern.matcher(legacy).replaceAll("$1$2");
-		StringBuilder builder = new StringBuilder();
-		char last = defaultColor;
-		for (int i = 0; i < legacy.length(); i++) {
-			char current = legacy.charAt(i);
-			if (current != '§' || i == legacy.length() - 1) {
-				builder.append(current);
-				continue;
-			}
-			current = legacy.charAt(++i);
-			if (current == last) continue;
-			builder.append('§').append(current);
-			last = current;
-		}
-		return builder.toString();
-	}
+    public static String removeUnusedColor(String legacy, char defaultColor, boolean isPrefix) {
+        if (legacy == null) return null;
+        Pattern pattern = isPrefix ? UNUSED_COLOR_PATTERN_PREFIX : UNUSED_COLOR_PATTERN;
+        legacy = pattern.matcher(legacy).replaceAll("$1$2");
+        StringBuilder builder = new StringBuilder();
+        char last = defaultColor;
+        for (int i = 0; i < legacy.length(); i++) {
+            char current = legacy.charAt(i);
+            if (current != '§' || i == legacy.length() - 1) {
+                builder.append(current);
+                continue;
+            }
+            current = legacy.charAt(++i);
+            if (current == last) continue;
+            builder.append('§').append(current);
+            last = current;
+        }
+        return builder.toString();
+    }
 }


### PR DESCRIPTION
Currently a prefix may be cut, despite of it actually fitting in 16 characters.
Here is an example:
```
{"extra":[{"color":"dark_green","text":"P"},{"bold":true,"color":"dark_green","text":"+ "},{"color":"dark_gray","text":"┃ "}],"text":""}
§f§2P§2§l+ §8┃ §2
§f§2P§2§l+ §8┃ §
§f§2P§2§l+ §8┃
```
The last color will be cut off, but actually it could fit without the unnecessary §f and the second §2.
The same prefix with this fix will be transformed into the following:
``§2P§l+ §8┃ §2``

The code is copied from [ViaRewind](https://github.com/Gerrygames/ViaRewind/blob/master/core/src/main/java/de/gerrygames/viarewind/utils/ChatUtil.java#L23) and has been modified slightly to work with prefixes.